### PR TITLE
Fixed Fawe Gradle Compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,13 @@ repositories {
         url = 'http://maven.sk89q.com/repo/'
     }
     maven { url = "https://mvn.intellectualsites.com/content/repositories/releases/" }
+
+    // Commons - IO
+    maven { url = "https://mvnrepository.com/artifact/commons-io/commons-io" }
+
+    // WorldEdit
+    maven { url = "http://maven.enginehub.org/repo/" }
+
     mavenCentral()
 }
 
@@ -174,10 +181,10 @@ dependencies {
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     compileOnly 'com.mojang:authlib:1.5.25'
 	compileOnly 'org.projectlombok:lombok:1.18.14'
-    compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.0.0-SNAPSHOT'
-    compileOnly 'com.sk89q.worldedit:worldedit-core:7.0.0-SNAPSHOT'
-    compile files('C:/Users/train/Desktop/Programing/Git/worldsystem/lib/commons-io-2.7.jar')
-    compile files('C:/Users/train/Desktop/Programing/Git/worldsystem/lib/FastAsyncWorldEdit.jar')
+    compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.0-SNAPSHOT'
+    compileOnly 'com.sk89q.worldedit:worldedit-core:7.2.0-SNAPSHOT'
+    compile group: 'commons-io', name: 'commons-io', version: '2.7'
+    compileOnly files('dependency/FastAsyncWorldEdit.jar')
 }
 
 shadowJar {


### PR DESCRIPTION
Fawe is no longer directly compiled into the plugin. Further wordledit api was updated to 7.2

I still have to do testing*